### PR TITLE
Readsize tutorial edits

### DIFF
--- a/articles/tutorials/tune-readsize.md
+++ b/articles/tutorials/tune-readsize.md
@@ -359,7 +359,7 @@ shows that the hardware buffer does not accumulate data:
 > -   **As of OpenEphys.Onix1 0.7.0:** As long as you stay above the minimum
 >     mentioned in the previous bullet point, `ReadSize` can be set to any value
 >     by the user. The OpenEphys.Onix1 Bonsai package will round this `ReadSize`
->     to the nearest multiple of four and uses that value instead. For example,
+>     up to the next multiple of four and uses that value instead. For example,
 >     if you try to set `ReadSize` to 887, the software will use the value 888
 >     instead.
 > -   If you are using a data I/O operator that has capacity to produce data at

--- a/articles/tutorials/tune-readsize.md
+++ b/articles/tutorials/tune-readsize.md
@@ -21,16 +21,16 @@ times can be achieved.
 
 ## Hardware Buffer and ReadSize
 
-Data is transferred in `ReadSize`-bytes chunks from ONIX to the host computer.
+Data is transferred in chunks containing `ReadSize`-bytes from ONIX to the host computer.
 This `ReadSize` value can be set by the user. If `ReadSize` is so small that
 ONIX produces `ReadSize` bytes of data faster than the host computer can perform
 a read operation, newly produced data is streamed to ONIX's hardware buffer
 instead of directly to the host's RAM. If this happens too much, closed-loop
 feedback performance suffers and the likelihood of hardware buffer overflow
 increases. However, if `ReadSize` is so large that it takes a long time for ONIX
-to produce a `ReadSize` amount of data, a single `ReadSize`-chunk contains data
-from a larger span of time. This increases the average closed-loop latency. The
-goal is to set a `ReadSize` that balances these consideration. The rest of this
+to produce that amount of data, a single `ReadSize` chunk of data
+spans a larger period of time. This increases the average closed-loop latency. The
+goal is to set a `ReadSize` that balances these considerations. The rest of this
 section describes ONIX-to-host data transfers in greater technical detail to
 help better understand this balancing act.
 
@@ -361,7 +361,7 @@ shows that the hardware buffer does not accumulate data:
 >     mentioned in the previous bullet point, `ReadSize` can be set to any value
 >     by the user. The OpenEphys.Onix1 Bonsai package will round this `ReadSize`
 >     up to the next multiple of four and uses that value instead. For example,
->     if you try to set `ReadSize` to 887, the software will use the value 888
+>     if you try to set `ReadSize` to 885, the software will use the value 888
 >     instead.
 > -   If you are using a data I/O operator that has capacity to produce data at
 >     various rates (like <xref:OpenEphys.Onix1.DigitalInput>), test your chosen

--- a/articles/tutorials/tune-readsize.md
+++ b/articles/tutorials/tune-readsize.md
@@ -413,4 +413,3 @@ necessarily increases the total data throughput of
 the latency measurements will not reflect the latencies you will experience
 during the actual experiment. 
 
-<!-- ## Tuning `ReadSize` with Real-Time Computation -->

--- a/articles/tutorials/tune-readsize.md
+++ b/articles/tutorials/tune-readsize.md
@@ -61,12 +61,11 @@ There are a couple of things to note about this process:
    buffer must be filled with `ReadSize` bytes before software can access it, it
    is physically impossible to achieve lower latencies than this. The goal of
    this tutorial is to allow your system to operate in this regime.
-3. If ONIX is produces data while data is being transferred to or waiting to be
-   consumed by the host, this stream of new data is redirected to the ONIX
-   `Hardware Buffer`. The ONIX hardware buffer consists of 2GB of dedicated RAM
-   that belongs to the acquisition hardware (it is _not_ RAM in the host
-   computer). The hardware buffer temporarily stores data that has not yet been
-   transferred to the host.     
+3. If ONIX produces data faster than it is transferred to and consumed by the
+   host, this stream of new data is redirected to the ONIX `Hardware Buffer`.
+   The ONIX hardware buffer consists of 2GB of dedicated RAM that belongs to the
+   acquisition hardware (it is _not_ RAM in the host computer). The hardware
+   buffer temporarily stores data that has not yet been transferred to the host.     
 
 The size of hardware to host data transfers is determined by the
 <xref:OpenEphys.Onix1.StartAcquisition.ReadSize> property of the
@@ -81,12 +80,14 @@ each transfer requires calls to the kernel driver, they incur significant
 overhead. If `ReadSize` is so small that the average time it takes to perform a
 data transfer is longer than the time it takes the hardware to produce a
 `ReadSize` amount of data, data will accumulate in the Hardware Buffer. This
-will destroy real-time performance and eventually cause the hardware buffer to
-overflow, terminating acquisition. Larger `ReadSize` values mean that more data
-needs to accumulate before the kernel driver relinquishes control of the buffer
-to software. This means more time needs to pass before software can start
-operating on data. This increases average latency but reduces the risk of
-accumulating data in the ONIX hardware buffer.
+will destroy real-time performance and risks overflowing the hardware buffer,
+terminating acquisition. Larger `ReadSize` values mean that more data needs to
+accumulate before the kernel driver relinquishes control of the buffer to
+software. This means more time needs to pass before software can start operating
+on data. This increases average latency but reduces the risk of accumulating
+data in the ONIX hardware because transferring the same amount of data at a
+larger `ReadSize` incurs less overhead in the form of calls to the kernel
+driver.
 
 ## Tuning `ReadSize` to Optimize Closed Loop Performance
 

--- a/articles/tutorials/tune-readsize.md
+++ b/articles/tutorials/tune-readsize.md
@@ -23,7 +23,7 @@ times can be achieved.
 
 Data is transferred in chunks containing `ReadSize`-bytes from ONIX to the host computer.
 This `ReadSize` value can be set by the user. If `ReadSize` is so small that
-ONIX produces `ReadSize` bytes of data faster than the host computer can perform
+ONIX produces that amount of data faster than the host computer can perform
 a read operation, newly produced data is streamed to ONIX's hardware buffer
 instead of directly to the host's RAM. If this happens too much, closed-loop
 feedback performance suffers and the likelihood of hardware buffer overflow


### PR DESCRIPTION
Fix technical description.

- The first commit contains jonnew's technical description of the onix-to-host data transfer process, unadulterated. 
- The second commit contains my edits. The message for this commit contains the list of all the edits I made.

--- 

- The third commit fixes #271 