### PR TITLE
Update actions versions as Node.js 20 actions are deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: windows-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: true
 
@@ -34,14 +34,14 @@ jobs:
         run: .\docfx-utils.ps1 -b
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: _site
           path: _site
           if-no-files-found: error
       
       - name: Upload GitHub Pages Artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: _site
 
@@ -51,13 +51,13 @@ jobs:
     needs: build
     steps:
       - name: Download Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: _site
           path: _site
 
       - name: Restore lychee cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .lycheecache
           key: cache-lychee-${{ github.sha }}
@@ -84,4 +84,4 @@ jobs:
       
     steps:
       - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Check HTML Links After Building
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --root-dir "${{ github.workspace }}/_site" --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* --max-retries 0 --max-concurrency 32 --cache --max-cache-age 1d '**/*.html'
+          args: --verbose --no-progress --root-dir "${{ github.workspace }}/_site" --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* --exclude '\.(pdf)$' --max-retries 0 --max-concurrency 32 --cache --max-cache-age 1d '**/*.html'
           fail: true
 
   deploy:

--- a/articles/hardware/ucla-miniscope-v4/overview.md
+++ b/articles/hardware/ucla-miniscope-v4/overview.md
@@ -15,7 +15,7 @@ These are the devices available on the UCLA Miniscope v4:
   rate as the camera
 
 > [!TIP]
-> Visit the [UCLA Miniscope v4 Hardware Guide](https://open-ephys.github.io/miniscope-docs/ucla-miniscope-v4/index.html) to learn more about the hardware such as weight, dimensions, and proper power voltages.
+> Visit the [UCLA Miniscope v4 Hardware Guide](https://open-ephys.github.io/miniscope-docs/Hardware-Guide/miniscope-v4/index.html) to learn more about the hardware such as weight, dimensions, and proper power voltages.
 
 The example workflow below can be copy/pasted into the Bonsai editor using the clipboard icon in the top right. This workflow:
 - Captures image data from the UCLA Miniscope v4 Camera System and saves it to disk.


### PR DESCRIPTION
As per [this article](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), all actions running Node 20 are being deprecated, and must be moved to Node 24.