### PR TITLE
Fix site-wide doc issues found during review

### DIFF
--- a/articles/getting-started/install-configure-bonsai.md
+++ b/articles/getting-started/install-configure-bonsai.md
@@ -20,7 +20,7 @@ To download Bonsai, select between the portable download and the installer downl
 > When using multiple environments, create and name shortcuts such that different Bonsai
 > environments are easier to find and distinguish.
 
-## Package Installation
+## Package Management
 
 Bonsai packages expand the set of operators available to you for building useful
 workflows. For example, the `OpenEphys.Onix1` package is required to interface
@@ -66,7 +66,7 @@ It is good practice to periodically check for package updates. To do this, open 
 1. Click the `Update` tab.
 1. Set `Package source` to `All`.
 1. Leave the search bar blank if you want to check for updates for all installed
-   packages.Alternatively, if you want to check for an update for a particular
+   packages. Alternatively, if you want to check for an update for a particular
    package, you may type that package's name in the search bar to expedite the
    update retrieval process.
 1. Click `Update All` if you want to perform all available updates that appear

--- a/articles/getting-started/install-configure-bonsai.md
+++ b/articles/getting-started/install-configure-bonsai.md
@@ -8,40 +8,39 @@ title: Installation
 To download Bonsai, select between the portable download and the installer download
 [here](https://bonsai-rx.org/docs/articles/installation.html).
 
-*   The **Portable** download (.zip) installs a sand-boxed version of Bonsai.
-    Portable environments enable users to switch between different environments
-    to prevent package conflicts and use different versions of packages.
-    *   To install from the **Portable** download, extract the downloaded file. You can start the
-        portable Bonsai by running the `Bonsai.exe` that is inside the extracted folder.
-*   The **Installer** download (.exe) installs Bonsai and all its dependencies globally.
-    *   To install from the **Installer** download, run the downloaded `Bonsai-X.X.X.exe` file and
-        agree to the involved licenses. You can start the globally installed Bonsai by launching it
-        from the `Bonsai Setup` window after installing or searching for it in your OS's search
-        function, for example. 
+- **Portable** (.zip): Installs a sandboxed version of Bonsai, keeping packages
+  isolated from other environments. Extract the downloaded file and run `Bonsai.exe`
+  from the extracted folder.
+
+- **Installer** (.exe): Installs Bonsai and all its dependencies globally. Run the
+  downloaded `Bonsai-X.X.X.exe` file, agree to the licenses, and launch Bonsai from
+  the `Bonsai Setup` window or your OS search.
 
 > [!TIP]
 > When using multiple environments, create and name shortcuts such that different Bonsai
-> environments are easier to find and distinguish. 
+> environments are easier to find and distinguish.
 
 ## Package Installation
 
-Bonsai packages expand the set of operators available to you for building useful workflows. For
-example, the `OpenEphys.Onix1` package is required to interface with Onix hardware through Bonsai.
-
-### Open the Bonsai Package Manager 
-
-The Bonsai package manager can be accessed from Bonsai's landing window or its workflow editor:
+Bonsai packages expand the set of operators available to you for building useful
+workflows. For example, the `OpenEphys.Onix1` package is required to interface
+with Onix hardware through Bonsai. The Bonsai package manager can be accessed
+from Bonsai's landing window or its workflow editor:
 
 ![Package manager from splash page](../../images/bonsai-splash-page-package-manager-highlight.png){width=350px} or ![Package manager from editor](../../images/bonsai-editor-package-manager-highlight.png){width=425px}
 
-### Install Packages
+### Installing Packages
 
 The following packages are required to run the workflows in this documentation:
 
-* `OpenEphys.Onix1.Design`: An extension of the `OpenEphys.Onix1` library that includes graphical user interfaces (GUIs). Installing OpenEphys.Onix1.Design automatically installs `OpenEphys.Onix1` as a dependency.
-* `Bonsai.StarterPack`: the "standard library" for Bonsai that contains tools that are used in almost every workflow.
-* `OpenEphys.Commutator`: for controlling Open Ephys commutators.
-* `OpenEphys.Sockets.Bonsai`: for establishing TCP Sockets (to stream data to the Open Ephys GUI, for example).
+- `OpenEphys.Onix1.Design`: An extension of the `OpenEphys.Onix1` library that
+  includes graphical user interfaces (GUIs). Installing OpenEphys.Onix1.Design
+  automatically installs `OpenEphys.Onix1` as a dependency.
+- `Bonsai.StarterPack`: the "standard library" for Bonsai that contains tools
+  that are used in almost every workflow.
+- `OpenEphys.Commutator`: for controlling Open Ephys commutators.
+- `OpenEphys.Sockets.Bonsai`: for establishing TCP Sockets (to stream data to
+  the Open Ephys GUI, for example).
 
 > [!TIP]
 > Additional packages will allow you to extend the functionality of ONIX hardware beyond the scope
@@ -52,40 +51,43 @@ The following packages are required to run the workflows in this documentation:
 
 To install packages, open the package manager and:
 
-1.  Click the `Browse` tab.
-1.  Set `Package source` to `All`.
-1.  Search for the exact package name listed above, e.g. `OpenEphys.Onix1.Design`.
-1.  Click `Install`.
-1.  If a license agreement window appears, click `I Accept`.
+1. Click the `Browse` tab.
+1. Set `Package source` to `All`.
+1. Search for the exact package name listed above, e.g. `OpenEphys.Onix1.Design`.
+1. Click `Install`.
+1. If a license agreement window appears, click `I Accept`.
 
 ![Bonsai OpenEphys.Onix1.Design Install Screenshot](../../images/bonsai-install-OpenEphys.Onix1.Design.webp){width=650px}
 
-### Update Packages
+### Updating Packages
 
 It is good practice to periodically check for package updates. To do this, open the package manager and:
 
-1.  Click the `Update` tab.
-1.  Set `Package source` to `All`.
-1.  Leave the search bar blank if you want to check for updates for all installed packages.\
-    Alternatively, if you want to check for an update for a particular package, you may type that package's name in the search bar to expedite the update retrieval process.
-1.  Click `Update All` if you want to perform all available updates that appear in the package browser.\
-    Alternatively, click on a package and click `Update` if you want to perform a subset of the available updates.
+1. Click the `Update` tab.
+1. Set `Package source` to `All`.
+1. Leave the search bar blank if you want to check for updates for all installed
+   packages.Alternatively, if you want to check for an update for a particular
+   package, you may type that package's name in the search bar to expedite the
+   update retrieval process.
+1. Click `Update All` if you want to perform all available updates that appear
+  in the package browser. Alternatively, click on a package and click `Update`
+  if you want to perform a subset of the available updates.
 
 ![Bonsai Update All or Just One Screenshot](../../images/bonsai-update.webp){width=650px}
 
-### Uninstall Packages
+### Uninstalling Packages
 
 Sometimes it is helpful to uninstall packages. Open the package manager and:
 
-1.  Click the `Installed` tab.
-1.  Set `Package source` to `All`.
-1.  Leave the search bar blank if you want to see all installed packages.\
-    Alternatively, if you want to uninstall a particular package, you may type that package's name in the search bar.
-1.  Click a package and click `Uninstall`.
+1. Click the `Installed` tab.
+1. Set `Package source` to `All`.
+1. Leave the search bar blank if you want to see all installed packages.
+   Alternatively, if you want to uninstall a particular package, you may type
+   that package's name in the search bar.
+1. Click a package and click `Uninstall`.
 
 ![Bonsai Uninstall Screenshot](../../images/bonsai-uninstall-Bonsai.OpenEphys.webp){width=650px}
 
-## Next Step
-
-Now that Bonsai and pertinent packages are installed, the next step is to learn how to use the
-workflow editor to place operators from these newly acquired packages into a workflow.
+Now that Bonsai and pertinent packages are installed, the next step is to learn
+how to use the workflow editor to place operators from these newly acquired
+packages into a workflow.

--- a/articles/getting-started/onix-acquisition.md
+++ b/articles/getting-started/onix-acquisition.md
@@ -13,7 +13,7 @@ Streaming data from ONIX hardware into Bonsai requires at least one [data source
 operator](xref:datasource).Place a data source operator and set its DeviceName
 property for every device from which you would like to stream. Setting the
 DeviceName property will tell the operator from which device to stream data.
-This is referred to linking the data source operator to the device. Take this
+This is referred to as linking the data source operator to the device. Take this
 workflow for example:
 
 ::: workflow

--- a/articles/getting-started/onix-acquisition.md
+++ b/articles/getting-started/onix-acquisition.md
@@ -10,13 +10,11 @@ operators](xref:datasink). This section covers how to use them.
 ## Acquiring Data
 
 Streaming data from ONIX hardware into Bonsai requires at least one [data source
-operator](xref:datasource).
-
-### Set up data source operator(s)
-
-Place a data source operator and set its DeviceName property for every device from which you would like
-to stream. Setting the DeviceName property will tell the operator from which device to stream data.
-This is referred to linking the data source operator to the device. Take this workflow for example:
+operator](xref:datasource).Place a data source operator and set its DeviceName
+property for every device from which you would like to stream. Setting the
+DeviceName property will tell the operator from which device to stream data.
+This is referred to linking the data source operator to the device. Take this
+workflow for example:
 
 ::: workflow
 ![Workflow with data operator](../../workflows/getting-started/polled-bno055.bonsai)
@@ -27,10 +25,16 @@ AnalogIO device on the breakout board.
 
 ## Use Multiple Instances of Identical Hardware
 
+When using multiple identical headstages or miniscopes, configuration operators
+must be given unique `Name` properties so their devices can be distinguished.
+When running more than one ONIX system on the same computer, each system's
+configuration chain must be assigned a unique `Index`. The following sections
+show how to do this.
+
 ### Multiple headstages/miniscopes
 
-Linking the data source operator to devices when using two identical headstages or
-miniscopes involves an additional step: renaming a configuration operator.
+Linking the data source operator to devices when using two identical headstages
+or miniscopes involves an additional step: renaming a configuration operator.
 Suppose you want to stream orientation data from two Neuropixels 2.0 Headstages
 through using two <xref:OpenEphys.Onix1.PolledBno055Data> operators. By default,
 the <xref:OpenEphys.Onix1.ConfigureHeadstageNeuropixelsV2e> operators are both
@@ -45,11 +49,10 @@ After this, the disambiguated source can be selected for each data operator
 
 ![Select a source for a Data operator](../../images/select-alternative-data-sources.png){width=650px}
 
-
 In the following workflow, the `Name` property of each
 <xref:OpenEphys.Onix1.ConfigureHeadstageNeuropixelsV2e> has been changed from
-"HeadstageNeuropixelsV2e" to "HS-NPX-A" and "HS-NPX-B". The `DeviceName` of
-each of the <xref:OpenEphys.Onix1.PolledBno055Data> operators has been set to
+"HeadstageNeuropixelsV2e" to "HS-NPX-A" and "HS-NPX-B". The `DeviceName` of each
+of the <xref:OpenEphys.Onix1.PolledBno055Data> operators has been set to
 "HS-NPX-A/PolledBno055" and "HS-NPX-B/PolledBno055" from the dropdown so each
 operator will take data from a different headstage.
 

--- a/articles/tutorials/calibrate-ts4231.md
+++ b/articles/tutorials/calibrate-ts4231.md
@@ -29,9 +29,9 @@ coordinates measured by the TS4231 device to the user-defined coordinate system.
 1. Copy the following workflow into the Bonsai workflow editor by hovering over
    the workflow image and clicking on the clipboard icon that appears.
 
-   ::: workflow ![SVG of copyable TS4231 calibration
-   workflow](../../workflows/tutorials/calibrate-ts4231/calibrate-ts4231.bonsai)
-   :::
+    ::: workflow
+    ![SVG of copyable TS4231 calibration workflow](../../workflows/tutorials/calibrate-ts4231/calibrate-ts4231.bonsai)
+    :::
 
    Open Bonsai and paste this workflow by clicking the Bonsai workflow editor
    pane and pressing <kbd>Ctrl+V</kbd>.

--- a/articles/tutorials/calibrate-ts4231.md
+++ b/articles/tutorials/calibrate-ts4231.md
@@ -23,7 +23,7 @@ coordinates measured by the TS4231 device to the user-defined coordinate system.
    in the ONIX Hardware docs.
 1. Follow the [Getting Started](xref:getting-started) guide to set up and
    familiarize yourself with Bonsai. In particular, [download the necessary
-   Bonsai packages](xref:install-configure-bonsai#package-installation) or
+   Bonsai packages](xref:install-configure-bonsai#package-management) or
    [check for updates](xref:install-configure-bonsai#updating-packages) if they're
    already installed.
 1. Copy the following workflow into the Bonsai workflow editor by hovering over
@@ -71,7 +71,7 @@ coordinates measured by the TS4231 device to the user-defined coordinate system.
 
     ![Screenshot of blank TS4231V1 Calibration GUI](../../images/tutorials/calibrate-ts4231/calibration-gui.png)
 
-1. ark four points in your behavioral arena. The position coordinates of these
+1. Mark four points in your behavioral arena. The position coordinates of these
    four points will be measured both in the TS4231 reference frame by the
    TS4231 device itself and in the user-defined reference frame. Here is a
    simple way to choose the four points:

--- a/articles/tutorials/calibrate-ts4231.md
+++ b/articles/tutorials/calibrate-ts4231.md
@@ -17,69 +17,69 @@ coordinates measured by the TS4231 device to the user-defined coordinate system.
 
 ## Setup
 
-1.  First, confirm the Lighthouse transmitters are properly mounted according to
-    the [Lighthouse Setup
-    Guide](https://open-ephys.github.io/onix-docs/Hardware%20Guide/Lighthouses/setup.html)
-    in the ONIX Hardware docs.
-1.  Follow the [Getting Started](xref:getting-started) guide to set up and
-    familiarize yourself with Bonsai. In particular, [download the necessary
-    Bonsai packages](xref:install-configure-bonsai#package-installation) or
-    [check for updates](xref:install-configure-bonsai#update-packages) if
-    they're already installed. 
-1.  Copy the following workflow into the Bonsai workflow editor by hovering over
-    the workflow image and clicking on the clipboard icon that appears.
+1. First, confirm the Lighthouse transmitters are properly mounted according to
+   the [Lighthouse Setup
+   Guide](https://open-ephys.github.io/onix-docs/Hardware%20Guide/Lighthouses/setup.html)
+   in the ONIX Hardware docs.
+1. Follow the [Getting Started](xref:getting-started) guide to set up and
+   familiarize yourself with Bonsai. In particular, [download the necessary
+   Bonsai packages](xref:install-configure-bonsai#package-installation) or
+   [check for updates](xref:install-configure-bonsai#updating-packages) if they're
+   already installed.
+1. Copy the following workflow into the Bonsai workflow editor by hovering over
+   the workflow image and clicking on the clipboard icon that appears.
 
-    ::: workflow ![SVG of copyable TS4231 calibration
-    workflow](../../workflows/tutorials/calibrate-ts4231/calibrate-ts4231.bonsai)
-    :::
+   ::: workflow ![SVG of copyable TS4231 calibration
+   workflow](../../workflows/tutorials/calibrate-ts4231/calibrate-ts4231.bonsai)
+   :::
 
-    Open Bonsai and paste this workflow by clicking the Bonsai workflow editor
-    pane and pressing <kbd>Ctrl+V</kbd>.
+   Open Bonsai and paste this workflow by clicking the Bonsai workflow editor
+   pane and pressing <kbd>Ctrl+V</kbd>.
 
-    Visit the <xref:hs64_workflow> and <xref:hs64_ts4231> pages to develop a
-    foundation on how to use Bonsai to acquire data from an ONIX headstage that
-    has a TS4231 device. 
-1.  Before beginning the calibration process, confirm that the lighthouse
-    configuration can measure the position of your TS4231 device across the
-    entire desired range. To do this, [start the
-    workflow](xref:workflow-editor#starting-the-workflow) and confirm that the
-    <xref:OpenEphys.Onix1.TS4231V1PositionData> operator continually produces
-    data as you slowly move the headstage across the entire range of your arena
-    while inspecting the TS4231V1PositionData Position
-    [visualizer](xref:visualize-data). If at some point the TS4231V1PositionData
-    operator stops producing data during this process (e.g. the Position
-    visualizer stops updating), the TS4231 receivers are either obstructed from
-    or no longer within range of the Lighthouse base station transmitters.
-    Remedying this might require modifying the lighthouse configuration or
-    reducing the size of your arena.
+   Visit the <xref:hs64_workflow> and <xref:hs64_ts4231> pages to develop a
+   foundation on how to use Bonsai to acquire data from an ONIX headstage that
+   has a TS4231 device.
+1. Before beginning the calibration process, confirm that the lighthouse
+   configuration can measure the position of your TS4231 device across the
+   entire desired range. To do this, [start the
+   workflow](xref:workflow-editor#starting-the-workflow) and confirm that the
+   <xref:OpenEphys.Onix1.TS4231V1PositionData> operator continually produces
+   data as you slowly move the headstage across the entire range of your arena
+   while inspecting the TS4231V1PositionData Position
+   [visualizer](xref:visualize-data). If at some point the TS4231V1PositionData
+   operator stops producing data during this process (e.g. the Position
+   visualizer stops updating), the TS4231 receivers are either obstructed from
+   or no longer within range of the Lighthouse base station transmitters.
+   Remedying this might require modifying the lighthouse configuration or
+   reducing the size of your arena.
 
-    > [!TIP] 
-    > The simple linear transform that this tutorial implements fails to
-    > consider non-linearities that the lighthouses exhibit at large distances.
-    > For accurate calibration using the linear transform node in this tutorial,
-    > the size of the arena might need to be constrained. More advanced
-    > calibration methods can be more accurate over larger spaces.
+   > [!TIP]
+   > The simple linear transform that this tutorial implements fails to consider
+   > non-linearities that the lighthouses exhibit at large distances. For
+   > accurate calibration using the linear transform node in this tutorial, the
+   > size of the arena might need to be constrained. More advanced calibration
+   > methods can be more accurate over larger spaces.
 
 ## TS4231 Spatial Data Calibration
 
-1.  Open the TS4231V1 Position Calibration GUI. 
+1. Open the TS4231V1 Position Calibration GUI.
 
-    -   Start the workflow. 
-    -   Open the <xref:OpenEphys.Onix1.TS4231V1LinearTransform> Position visualizer.
-    -   Click TS4231V1LinearTransform node to show its properties in the properties panel.
-    -   Click the <kbd>...</kbd> next to the "SpatialTransform" property.
+    - Start the workflow.
+    - Open the <xref:OpenEphys.Onix1.TS4231V1LinearTransform> Position visualizer.
+    - Click TS4231V1LinearTransform node to show its properties in the properties panel.
+    - Click the <kbd>...</kbd> next to the "SpatialTransform" property.
 
     ![Screenshot of blank TS4231V1 Calibration GUI](../../images/tutorials/calibrate-ts4231/calibration-gui.png)
 
-1.  Mark four points in your behavioral arena. The position coordinates of these
-    four points will be measured both in the TS4231 reference frame by the
-    TS4231 device itself and in the user-defined reference frame. Here is a
-    simple way to choose the four points:
+1. ark four points in your behavioral arena. The position coordinates of these
+   four points will be measured both in the TS4231 reference frame by the
+   TS4231 device itself and in the user-defined reference frame. Here is a
+   simple way to choose the four points:
 
-    1.  The user-defined origin
-    2.  A point in the behavioral arena along the user-defined X-axis
-    3.  A point in the behavioral arena along the user-defined Y-axis
-    4.  A point in the behavioral arena along the user-defined Z-axis
+    1. The user-defined origin
+    2. A point in the behavioral arena along the user-defined X-axis
+    3. A point in the behavioral arena along the user-defined Y-axis
+    4. A point in the behavioral arena along the user-defined Z-axis
 
     > [!TIP]
     > Choosing the furthest extent along the X, Y, & Z axes minimizes the
@@ -93,22 +93,22 @@ coordinates measured by the TS4231 device to the user-defined coordinate system.
     The light red space is an arbitrarily-defined working area for this demo.
     Units are in cm.
 
-1.  For each of the four points defined in the previous step:
+1. For each of the four points defined in the previous step:
 
-    -   Choose a row in the TS4231V1 Calibration GUI to correspond to that
-        point. 
-    -   Place your TS4231 device at that point and click the <kbd>Measure</kbd>
-        button in the corresponding row. The GUI will start taking measurements
-        from the TS4231 device as long as the TS4231 device is within range of
-        and unobstructed from the lighthouse transmitter. If the TS4231
-        measurement completes successfully, the corresponding entry in the form
-        is automatically populated. Otherwise, that entry stays empty. In either
-        case, you will be informed of the result in the "Status Messages" text
-        box. If the TS4231 measurement fails, return to the step in the previous
-        section that describes how to make sure the lighthouse configuration
-        covers the entire area that your TS4231 device will occupy.
-    -   Populate the X, Y, and Z entries of the user-defined coordinates column
-        in the corresponding row.
+    - Choose a row in the TS4231V1 Calibration GUI to correspond to that
+      point.
+    - Place your TS4231 device at that point and click the <kbd>Measure</kbd>
+      button in the corresponding row. The GUI will start taking measurements
+      from the TS4231 device as long as the TS4231 device is within range of and
+      unobstructed from the lighthouse transmitter. If the TS4231 measurement
+      completes successfully, the corresponding entry in the form is
+      automatically populated. Otherwise, that entry stays empty. In either
+      case, you will be informed of the result in the "Status Messages" text
+      box. If the TS4231 measurement fails, return to the step in the previous
+      section that describes how to make sure the lighthouse configuration
+      covers the entire area that your TS4231 device will occupy.
+    - Populate the X, Y, and Z entries of the user-defined coordinates column in
+      the corresponding row.
 
     > [!TIP]
     > Be as precise and accurate as possible with both the placement of the
@@ -120,26 +120,26 @@ coordinates measured by the TS4231 device to the user-defined coordinate system.
     spatial transform matrix is automatically calculated. When the spatial
     transform matrix is calculated, this will be indicated in the GUI's bottom
     status strip and the spatial transform matrix text box such as in the
-    following screenshot: 
-    
+    following screenshot:
+
     ![Screenshot of TS4231V1 Calibration GUI with calculated matrix](../../images/tutorials/calibrate-ts4231/calibration-gui_matrix-calculated.png)
 
-1.  After the spatial transform is calculated, click OK to proceed. This updates
-    the spatial transform matrix used by the TS4231V1LinearTransform operator.
-    This recalibrated spatial transform matrix should be immediately apparent in
-    the TS4231V1LinearTransform position data visualizer.
-    
-    If you are presented with the following confirmation, return to the TS4231
-    Calibration GUI main form to fix the entries that were indicated invalid in
-    the confirmation dialog.
-    
-    ![Screenshot of TS4231V1 Calibration GUI confirmation dialog](../../images/tutorials/calibrate-ts4231/calibration-gui_confirmation-dialog.png)
+1. After the spatial transform is calculated, click OK to proceed. This updates
+   the spatial transform matrix used by the TS4231V1LinearTransform operator.
+   This recalibrated spatial transform matrix should be immediately apparent in
+   the TS4231V1LinearTransform position data visualizer.
+
+   If you are presented with the following confirmation, return to the TS4231
+   Calibration GUI main form to fix the entries that were indicated invalid in
+   the confirmation dialog.
+
+   ![Screenshot of TS4231V1 Calibration GUI confirmation dialog](../../images/tutorials/calibrate-ts4231/calibration-gui_confirmation-dialog.png)
 
 > [!IMPORTANT]
 > After calibrating the TS4231V1 spatial transform matrix, it is important to
 > not change the TS4231PositionData operator's P or Q property values or move
 > the lighthouse base stations. If anything is changed, the calibrated spatial
-> transform matrix will no longer be accurate. 
+> transform matrix will no longer be accurate.
 
 ## Verify TS4231 Calibration
 
@@ -151,7 +151,7 @@ points (none of which should be the four calibration points) and check that
 their calibrated coordinates are what you expect.
 
 Below is an animation of the 3D trajectory reconstructed in Python synced with video data for
-demonstration purposes. 
+demonstration purposes.
 
 <video controls style="width:100%">
   <source src="../../images/tutorials/calibrate-ts4231/ts4231-calibration-demo.mp4" type="video/mp4">

--- a/articles/tutorials/data-frame-writer.md
+++ b/articles/tutorials/data-frame-writer.md
@@ -14,134 +14,130 @@ metadata file is needed to read it correctly. This tutorial explains how to use
 (including optional compression), and efficiently load the resulting Arrow files
 in Python.
 
-The first section walks through how to save, load, and plot data written by a
-`DataFrameWriter` using Python. More detailed explanations are covered in the
-[Advanced](#advanced-arrow-topics) section at the end of this article.
+The first sections walk through how to save data using the `DataFrameWriter`
+operator and then load and plot the data `DataFrameWriter` using Python. More
+detailed explanations are covered in the [Advanced](#advanced-arrow-topics)
+section at the end of this article.
 
 > [!NOTE]
 > Arrow is supported by many scientific computing environments. For instance:
 >
-> - [Python](https://arrow.apache.org/docs/python/index.html)
->   - With [NumPy](https://arrow.apache.org/docs/python/numpy.html) integration
->   - With [Pandas](https://arrow.apache.org/docs/python/pandas.html) integration
->   - With [Polars](https://pola.rs/) integration
+> - [Python](https://arrow.apache.org/docs/python/index.html) (with
+>   [NumPy](https://arrow.apache.org/docs/python/numpy.html),
+>   [Pandas](https://arrow.apache.org/docs/python/pandas.html), and
+>   [Polars](https://pola.rs/) integration)
 > - [R](https://arrow.apache.org/docs/r/)
 > - [Julia](https://arrow.apache.org/julia/stable/)
 > - [Matlab](https://github.com/apache/arrow/blob/main/matlab/README.md)
 
-## Save Arrow data
+## Using DataFrameWriter
 
-Follow the [Getting Started](xref:getting-started) guide to set up and familiarize yourself with
-Bonsai. In particular:
+Before starting this tutorial, complete the following steps from the [Getting
+Started](xref:getting-started) guide:
 
-- [Install or update the required Bonsai packages](xref:install-configure-bonsai#install-packages),
+- [Install or update the required Bonsai packages](xref:install-configure-bonsai#installing-packages),
   including the latest `OpenEphys.Onix1` package.
-- Ensure your hardware is set up and working. Follow the [data acquisition quick start
-  guide](xref:data-acq-quick-start) for your hardware if you have not already.
+- Complete the [data acquisition quick start guide](xref:data-acq-quick-start)
+  for your hardware.
 
-### Set up a workflow
+### Setting up your workflow
 
 To follow along with this tutorial, you need a workflow that contains at least
-one `DataFrameWriter` node. `DataFrameWriter` is a
+one `DataFrameWriter` operator. `DataFrameWriter` is a
 <xref:datasink-dataframewriter> operator which accepts any data stream producing
 <xref:OpenEphys.Onix1.DataFrame> or <xref:OpenEphys.Onix1.BufferedDataFrame>
-elements, meaning it can be placed downstream of virtually any [data source
-node](xref:datasource). You can use the example workflow below which saves data
-from several Breakout Board devices. The scripts on this page assume you are
-loading data from this workflow. However, you can also add a `DataFrameWriter`
-node to a workflow and adapt the scripts according to your needs to follow along.
+elements, meaning it can be placed downstream of most [data source
+nodes](xref:datasource). You can use the example workflow below which saves data
+from several data sources on the Breakout Board. The scripts on this page assume
+you are loading data from this workflow. However, you can also add a
+`DataFrameWriter` node to a workflow and adapt the scripts according to your
+needs to follow along.
 
 ::: workflow
 ![workflow for testing DataFrameWriter with Breakout Board data](../../workflows/tutorials/data-frame-writer/data-frame-writer-example.bonsai)
 :::
 
-### Configure DataFrameWriter
+### Configuring DataFrameWriter
 
-`DataFrameWriter` exposes the following properties in the Bonsai property panel:
+`DataFrameWriter` exposes the following properties in the Editor's property
+panel:
 
-- **FileName** The path of the output file, including the `.arrow` extension (e.g.,
-  `data/memory-monitor.arrow`). Any intermediate directories in the path are created automatically
-  if they do not already exist.
+- **FileName** The path of the output file, including the `.arrow` extension
+  (e.g., `data/memory-monitor.arrow`). Any intermediate directories in the path
+  are created automatically if they do not already exist.
 
-- **Suffix** A modifier inserted into the file name just before the extension each time the
-  workflow starts. Choose one of three options:
-  - `None` (default): No suffix is added. If a file at the specified path already exists and
-    `Overwrite` is `false`, the workflow raises an error on startup.
-  - `FileCount`: Appends the count of files already in the same directory
-    with the same base name and extension (`0`, `1`, `2`, …). Use this to automatically number
-    successive recordings without having to rename the node before each run. Adding an underscore at
-    the end of the `FileName`, but before the extension, separates the suffix from the filename
-    (e.g., `data/memory-monitor_.arrow`).
-  - `Timestamp`: Appends an underscore followed by a high-resolution system timestamp at the moment
-    the file is created (ISO 8601 format), guaranteeing a unique file name for every run.
+- **Suffix** A modifier inserted into the file name just before the extension
+  each time the workflow starts. Choose one of three options:
+  - `None` (default): No suffix is added. If a file at the specified path
+    already exists and `Overwrite` is `false`, the workflow raises an error on
+    startup.
+  - `FileCount`: Appends the count of files already in the same directory with
+    the same base name and extension (`0`, `1`, `2`, …). Use this to
+    automatically number successive recordings without having to rename the node
+    before each run. Adding an underscore at the end of the `FileName`, but
+    before the extension, separates the suffix from the filename (e.g.,
+    `data/memory-monitor_.arrow`).
+  - `Timestamp`: Appends an underscore followed by a high-resolution system
+    timestamp at the moment the file is created (ISO 8601 format), guaranteeing
+    a unique file name for every run.
 
-- **Buffered** (default: `true`) When `true`, incoming frames are placed in a memory queue and
-  written to disk by a background thread, preventing disk I/O latency from blocking the acquisition
-  thread. Setting this to `false` writes synchronously on the acquisition thread, which is not
-  recommended for high-bandwidth data streams or when low latency feedback is required.
+- **Buffered** (default: `true`) When `true`, incoming frames are placed in a
+  memory queue and written to disk by a background thread, preventing disk I/O
+  latency from blocking the acquisition thread. Setting this to `false` writes
+  synchronously on the acquisition thread, which is not recommended for
+  high-bandwidth data streams or when low latency feedback is required.
 
-- **Overwrite** (default: `false`) When `true`, an existing file at the resolved path is
-  silently replaced when the workflow starts. When `false`, the workflow raises an error if the file
-  already exists. This setting has no practical effect when `Suffix` is `FileCount` or `Timestamp`,
-  because those modes always produce a unique file name.
+- **Overwrite** (default: `false`) When `true`, an existing file at the resolved
+  path is silently replaced when the workflow starts. When `false`, the workflow
+  raises an error if the file already exists. This setting has no practical
+  effect when `Suffix` is `FileCount` or `Timestamp`, because those modes always
+  produce a unique file name.
 
 - **EnableCompression** (default: `false`) When `true`, data is compressed
   before being written to disk to reduce file size at the cost of CPU overhead.
   See [Compression](#compression) in the [Advanced](#advanced-arrow-topics)
   section for more information on compression and when to use it.
 
-### Run the workflow
+### Running the workflow
 
-[Start the workflow](xref:workflow-editor#starting-the-workflow). `DataFrameWriter` will write
-data to the file specified in `FileName` as the workflow runs, and will stop when the workflow
-stops.
+[Start the workflow](xref:workflow-editor#starting-the-workflow).
+`DataFrameWriter` will write data to the file specified in `FileName` as the
+workflow runs, and will stop when the workflow stops.
 
-## Load Arrow data
+## Loading Arrow files in Python
 
 In Python, Arrow files can be read using
-[PyArrow](https://arrow.apache.org/docs/python/index.html). Notably, several
+[PyArrow](https://arrow.apache.org/docs/python/index.html). Several
 scientific analysis libraries such as [pandas](https://pandas.pydata.org/),
-[numpy](https://numpy.org/) and [Polars](https://pola.rs/), use PyArrow
-internally to support loading Arrow files into their environment. In this
-section, we will demonstrate file loading using both PyArrow and Pandas.
+[numpy](https://numpy.org/) and [Polars](https://pola.rs/) use PyArrow
+internally. This section demonstrates file loading using both PyArrow and
+Pandas. Install both packages using your preferred method before proceeding
+(e.g. `pip install pyarrow pandas`).
 
-> [!NOTE]
-> Some analysis libraries, such as [SpikeInterface](https://spikeinterface.readthedocs.io/), do not
-> yet have Arrow integration. For workflows that depend on those libraries, you will need to
-> [convert](#converting-to-other-formats) the data to another format (e.g., [NumPy
-> arrays](#exporting-to-numpy)) before passing it to SpikeInterface for processing. We are working
-> towards a more direct SpikeInterface integration.
+<!-- > [!NOTE]
+> [SpikeInterface](https://spikeinterface.readthedocs.io/) does not yet have
+> Arrow integration. For workflows that use SpikeInterface, you will need to
+> [convert](#converting-to-other-formats) the data to another format (e.g.,
+> [NumPy arrays](#exporting-to-numpy)) before passing it for processing. We are
+> working towards SpikeInterface integration. -->
 
-### Install Python and required packages
-
-Once Python is installed, run the following command to install the required packages:
-
-```
-pip install pyarrow pandas
-```
-
-### Download the loading script
-
-Download the loading script and place it in the same directory as your other processing scripts.
-The script provides a single public function, `load_arrow_file`, which loads data from an Arrow
-file efficiently using [zero-copy](https://en.wikipedia.org/wiki/Zero-copy) memory mapping. The optional
-`start`, `end`, and `columns` parameters allow loading only the rows and columns you need without
-reading the full file into memory.
-
-[Download loading script](../../scripts/tutorials/data-frame-writer/load_arrow.py)
+The following script provides a single public function, `load_arrow_file`, which
+loads data from an Arrow file efficiently using
+[zero-copy](https://en.wikipedia.org/wiki/Zero-copy) memory mapping. The
+optional `start`, `end`, and `columns` parameters allow loading only the rows
+and columns you need without reading the full file into memory. Place it in the
+same directory as your other processing scripts.
 
 <details>
-<summary>View the loading script inline.</summary>
+<summary><strong>load_arrow.py</strong><a class="details-download" href="../../scripts/tutorials/data-frame-writer/load_arrow.py" download>⬇ Download</a></summary>
 
 [!code-python[](../../scripts/tutorials/data-frame-writer/load_arrow.py)]
 </details>
 
-### Load Arrow file
+### Loading Arrow files
 
 To load the full Arrow file, simply call `load_arrow_file` with a string
 pointing to the file; this can be an absolute file path or a relative file path.
-
-[!code-python[](../../scripts/tutorials/data-frame-writer/load-file.py)]
 
 The optional `start` and `end` parameters are integers that specify the first
 and last row indices (0-based) to read from the file. The optional `columns`
@@ -160,16 +156,17 @@ match a column name in the file, a `KeyError` is raised.
 > Compressed and uncompressed files are loaded identically. PyArrow reads the
 > compression metadata in each record batch header and decompresses
 > automatically when necessary. This decompression process can incur CPU overhead
-> that extends the amount of time it takes to load a file. 
+> that extends the amount of time it takes to load a file.
 
 ### Converting to other formats
 
-PyArrow can convert Arrow tables into several other formats for use with different libraries and
-workflows.
+PyArrow can convert Arrow tables into several other formats for use with
+different libraries and workflows.
 
 #### Converting to a pandas DataFrame
 
-If your analysis uses pandas, you can convert an Arrow Table to a DataFrame by calling `.to_pandas()`:
+If your analysis uses pandas, you can convert an Arrow Table to a DataFrame by
+calling `.to_pandas()`:
 
 ```python
 from load_arrow import load_arrow_file
@@ -179,18 +176,19 @@ df = table.to_pandas()
 ```
 
 > [!IMPORTANT]
-> Calling `.to_pandas()`, or any other method that converts the table to a pandas DataFrame, might
-> copy the entire dataset into RAM. Pandas and PyArrow can, in certain limited circumstances,
-> maintain memory mapping across boundaries, but it is not guaranteed. Keep this in mind when
-> working with long recordings on machines with limited memory.
+> Calling `.to_pandas()`, or any other method that converts the table to a
+> pandas DataFrame, might copy the entire dataset into RAM. Pandas and PyArrow
+> can, in certain limited circumstances, maintain memory mapping across
+> boundaries, but it is not guaranteed. Keep this in mind when working with long
+> recordings on machines with limited memory.
 
 #### Using pandas directly
 
 It is also possible to load an Arrow file directly with Pandas using
 [`pandas.read_feather()`](https://pandas.pydata.org/docs/reference/api/pandas.read_feather.html),
 which accepts Arrow IPC files directly because [Feather
-v2](https://arrow.apache.org/docs/python/feather.html#feather-file-format) and Arrow IPC share the
-same binary format.
+v2](https://arrow.apache.org/docs/python/feather.html#feather-file-format) and
+Arrow IPC share the same binary format.
 
 ```python
 import pandas as pd
@@ -204,11 +202,12 @@ expose sample-index access, so there is no way to read only a portion of the
 recording without first loading the whole file. For large or long recordings,
 the memory-mapped approach described previously is preferable.
 
-#### Exporting to NumPy
+#### Exporting Arrow data to NumPy
 
-Individual columns can be extracted as NumPy arrays using `.to_numpy()`. For large recordings, pass
-start and end indices to `load_arrow_file()` (as shown [previously](#load-arrow-file)) to avoid
-loading the entire file into RAM at once.
+Individual columns can be extracted as NumPy arrays using `.to_numpy()`. For
+large recordings, pass start and end indices to `load_arrow_file()` (as shown
+[previously](#loading-arrow-files)) to avoid loading the entire file into RAM at
+once.
 
 ```python
 from load_arrow import load_arrow_file
@@ -219,28 +218,25 @@ percent_used = table["PercentUsed"].to_numpy()
 clock = table["Clock"].to_numpy()
 ```
 
-## Plot Arrow data
+## Plotting data from Arrow files
 
-The examples in this section also require `matplotlib`. Install it alongside the
-packages above if you have not already:
-
-```
-pip install matplotlib
-```
-
-To render and interact with figures, you will also need a `matplotlib` backend.
-See the [matplotlib backend
+The examples in this section also require `matplotlib` (e.g. `pip install
+matplotlib`). To display figures interactively, matplotlib needs a GUI backend.
+In Jupyter notebooks this is handled automatically. In a plain Python script,
+`plt.show()` will open a figure window if a compatible GUI toolkit (e.g. Tk, Qt,
+or wxPython) is installed. See the [matplotlib backend
 documentation](https://matplotlib.org/stable/users/explain/figure/backends.html)
-for installation instructions.
+if figures do not appear.
 
-This section shows how to plot data saved from a `MemoryMonitor` device. The
-MemoryMonitor schema contains columns including `Clock`, `PercentUsed`, and
-`BytesUsed`. The `Clock` column records the raw acquisition clock count and must
-be divided by the acquisition clock rate to produce a time value in seconds.
+This section shows how to plot data saved from a
+<xref:OpenEphys.Onix1.MemoryMonitorData> operator. The MemoryMonitor schema
+contains columns including `Clock`, `PercentUsed`, and `BytesUsed`. The `Clock`
+column records the acquisition clock counter value and must be divided by the
+acquisition clock rate convert its value to seconds.
 
 ### Reading the acquisition clock rate
 
-The example workflow shown [above](#set-up-a-workflow) writes
+The example workflow shown [above](#setting-up-your-workflow) writes
 acquisition metadata, including the clock rate, to a `start-time_<suffix>.csv`
 file each time it runs. Load it with NumPy before plotting:
 
@@ -287,9 +283,9 @@ plt.show()
 
 ### Plotting with pandas
 
-Converting the Arrow table to a pandas DataFrame gives access to pandas's `.plot()` method and
-column-based indexing, which can make exploratory analysis more concise. The pandas workflow for
-the memory monitor data looks like this:
+Converting the Arrow table to a pandas DataFrame gives access to pandas's
+`.plot()` method and column-based indexing, which can make exploratory analysis
+more concise. The pandas workflow for the memory monitor data looks like this:
 
 ```python
 import numpy as np
@@ -329,9 +325,10 @@ plt.show()
 ```
 
 > [!IMPORTANT]
-> Calling `.to_pandas()` can copy the entire table into RAM, potentially exceeding
-> memory usage limits. For short recordings this is a convenient workflow, but for large files on
-> memory-limited machines, prefer working directly with the PyArrow table as shown above.
+> Calling `.to_pandas()` can copy the entire table into RAM, potentially
+> exceeding memory usage limits. For short recordings this is a convenient
+> workflow, but for large files on memory-limited machines, prefer working
+> directly with the PyArrow table as shown above.
 
 ## Working with subsampled data
 
@@ -340,13 +337,15 @@ different rates. For example, <xref:OpenEphys.Onix1.NeuropixelsV1DataFrame>
 combines AP-band spike data sampled at 30 kHz and LFP-band data sampled at 2.5
 kHz. Because all columns share the row count of the faster AP-band stream, each
 LFP value repeats 12 rows in the loaded data. The following script extracts only
-the unique LFP samples and their corresponding `Clock` values from the loaded data.
+the unique LFP samples and their corresponding `Clock` values from the loaded
+data.
 
 [!code-python[](../../scripts/tutorials/data-frame-writer/load-subsampled-data.py)]
 
-Divide `clock_unique` by the acquisition clock rate to convert clock counts to seconds. See
-[Reading the acquisition clock rate](#reading-the-acquisition-clock-rate) for how to load that
-value from the metadata CSV file.
+Divide `clock_unique` by the acquisition clock rate to convert clock counts to
+seconds. See [Reading the acquisition clock
+rate](#reading-the-acquisition-clock-rate) for how to load that value from the
+metadata CSV file.
 
 See the [Subsampled data](#subsampled-data) section for a more detailed
 explanation.
@@ -362,12 +361,12 @@ filtering, grouping, and aggregation. Concretely, samples from a single data
 source, e.g. a single electrophysiology channel, are stored next to each other
 on disk. This means an analysis tool can read just the channels it needs without
 first rearranging or copying the contents of the file after it has been loaded
-into memory. Additionally, each file is self-describing: it opens with a schema that
-declares every column's name and data type, followed by a sequence of [record
+into memory. Additionally, each file is self-describing: it opens with a schema
+that declares every column's name and data type, followed by a sequence of
+[record
 batches](https://arrow.apache.org/docs/format/Glossary.html#term-record-batch).
 Each record batch is a group of rows in which each column's values are stored as
-a contiguous array. Unlike plain text data formats
-(e.g. CSV files produced by
+a contiguous array. Unlike plain text data formats (e.g. CSV files produced by
 [CsvWriter](https://bonsai-rx.org/docs/api/Bonsai.IO.CsvWriter.html)) or flat
 binary files (e.g. files produced by
 [MatrixWriter](https://bonsai-rx.org/docs/api/Bonsai.Dsp.MatrixWriter.html)),
@@ -376,21 +375,20 @@ floating point numbers, etc.), and do not require a separate metadata file or
 prior knowledge of the data layout in order to be loaded correctly.
 
 > [!NOTE]
-> To convert from Arrow files to a format similar to the output of `CsvWriter` or `MatrixWriter`,
-> check out [this section](#converting-to-other-formats) for details on how to convert the data into
-> other formats.
+> To convert from Arrow files to a format similar to the output of `CsvWriter`
+> or `MatrixWriter`, check out [this section](#converting-to-other-formats) for
+> details on how to convert the data into other formats.
 
-### How data is written
+### DataFrameWriter Batching and Flush Behavior
 
-`DataFrameWriter` does not write one row to disk per incoming frame. Instead, it
-accumulates frames into an in-memory buffer and writes them to disk as a single
-record batch. The target buffer size is determined automatically by the data
-frame type and is not user-configurable. The data in the buffer is written to
-disk when it reaches that size or after at most five seconds, whichever comes
-first.
-
-This batching strategy keeps disk I/O efficient without placing any special
-requirements on your workflow structure.
+<xref:OpenEphys.Onix1.DataFrameWriter.DataFrameWriter> accumulates incoming
+frames in memory and writes them to disk as Arrow record batches. For periodic
+data sources (e.g. Neuropixels or Intan Chips), each batch holds approximately
+one second of data. For aperiodic or bursty sources (e.g. Digital Inputs), batch
+sizes vary; a flush is triggered after at most five seconds regardless of how
+many samples have accumulated. This design balances read and write performance,
+file size, and [worst-case data loss](#loading-and-recovering-corrupt-files) in
+the event of a catastrophic failure such as a power outage.
 
 ### Compression
 
@@ -405,6 +403,7 @@ workflows with long recordings or low-latency (e.g., sub-millisecond)
 closed-loop feedback, benchmark the system with compression enabled.
 
 > [!TIP]
+>
 > - To evaluate the impact of compression on your specific setup, compare the
 >   data from a <xref:OpenEphys.Onix1.MemoryMonitorData> operator to examine the
 >   state of the hardware buffer when `EnableCompression` is set to `true` and
@@ -412,8 +411,8 @@ closed-loop feedback, benchmark the system with compression enabled.
 >   both cases, compression does not risk buffer overflow and might not be
 >   impacting the real-time performance. Refer to the [Tuning closed-loop
 >   performance tutorial](xref:tune-readsize) for more information.
-> - Enabling the [`Buffered` property](#configure-dataframewriter) can
->   alleviate the CPU overhead by offloading compression to a background thread. 
+> - Enabling the [`Buffered` property](#configuring-dataframewriter) can
+>   alleviate the CPU overhead by offloading compression to a background thread.
 
 ### Subsampled data
 
@@ -436,17 +435,18 @@ calculated.
 
 ### Manually Loading Arrow Files
 
-The scripts provided in the [loading section](#load-arrow-data) utilize the [provided
-script](#download-the-loading-script) to handle loading data without you needing to know any specifics about how
-to access the data. In this section, we provide some code snippets that could be used to manually
-interact with the Arrow file in cases where the provided script does not meet some need.
+The scripts in the [loading section](#loading-arrow-files) abstract the details
+of Arrow file access. This section covers lower-level Arrow API usage for cases
+where direct control is needed or the provided scripts do not meet specific
+requirements.
 
 #### Memory-mapped loading
 
-The most efficient way to read Arrow files in Python is to open the file as a memory map and pass it
-to `pyarrow.ipc.open_file()`. With this approach, PyArrow maps the file into the process's virtual
-address space and reads data on demand rather than copying the entire file into RAM upfront. For large
-recordings, this is significantly more memory-efficient than loading everything at once.
+The most efficient way to read Arrow files in Python is to open the file as a
+memory map and pass it to `pyarrow.ipc.open_file()`. With this approach, PyArrow
+maps the file into the process's virtual address space and reads data on demand
+rather than copying the entire file into RAM upfront. For large recordings, this
+is significantly more memory-efficient than loading everything at once.
 
 ```python
 import pyarrow as pa
@@ -458,8 +458,9 @@ with pa.memory_map("memory-monitor_0.arrow", "r") as source:
         table = reader.read_all()
 ```
 
-Individual record batches can be read one at a time, which is useful when you only need a subset of
-the data or when the full recording does not fit in available RAM:
+Individual record batches can be read one at a time, which is useful when you
+only need a subset of the data or when the full recording does not fit in
+available RAM:
 
 ```python
 import pyarrow as pa
@@ -501,26 +502,28 @@ following scripts can be used to recover a file that has closed exceptionally.
 
 #### Recovering an Arrow file with invalid footer
 
-If recording is interrupted, the file may be missing the footer that Arrow uses to index record
-batches, causing PyArrow to raise `ArrowInvalid: Not an Arrow file` when you try to open it. This
-script works around the missing footer by opening the file as an Arrow Stream rather than an Arrow
-File. The Stream format reads record batches sequentially without relying on the footer, so all
-batches written before the interruption can still be recovered. The recovered batches are then
-written to a new file, which automatically generates a valid footer on close.
+If recording is interrupted, the file may be missing the footer that Arrow uses
+to index record batches, causing PyArrow to raise `ArrowInvalid: Not an Arrow
+file` when you try to open it. This script works around the missing footer by
+opening the file as an Arrow Stream rather than an Arrow File. The Stream format
+reads record batches sequentially without relying on the footer, so all batches
+written before the interruption can still be recovered. The recovered batches
+are then written to a new file, which automatically generates a valid footer on
+close.
 
 [!code-python[](../../scripts/tutorials/data-frame-writer/recover-invalid-footer.py)]
 
 #### Recovering an Arrow file with corrupted batches
 
-This script reads an Arrow file with an intact footer that has been corrupted in some other way
-(invalid buffers, corrupted headers, etc.) and writes all valid batches to a new file. One error
-that indicates the buffers or headers have been corrupted is `ArrowInvalid: Unexpected empty message
-in IPC file format`.
+This script reads an Arrow file with an intact footer that has been corrupted in
+some other way (invalid buffers, corrupted headers, etc.) and writes all valid
+batches to a new file. One error that indicates the buffers or headers have been
+corrupted is `ArrowInvalid: Unexpected empty message in IPC file format`.
 
-> [!WARNING] 
-> This script will discard any batches that have an error without attempting to correct
-> the error, leading to skips in the data. The `Clock` column can be inspected afterward to identify
-> gaps where batches were skipped.
+> [!WARNING]
+> This script will discard any batches that have an error without attempting to
+> correct the error, leading to skips in the data. The `Clock` column can be
+> inspected afterward to identify gaps where batches were skipped.
 
 [!code-python[](../../scripts/tutorials/data-frame-writer/recover-corrupted-batches.py)]
 
@@ -534,4 +537,3 @@ The change is the same for both recovery scripts above; this example uses the
 [invalid footer](#recovering-an-arrow-file-with-invalid-footer) script:
 
 [!code-python[](../../scripts/tutorials/data-frame-writer/recover-compressed-data.py)]
-

--- a/articles/tutorials/ephys-processing-listening.md
+++ b/articles/tutorials/ephys-processing-listening.md
@@ -6,7 +6,7 @@ title: Process and Listen to Ephys Data
 This tutorial shows you how to perform basic online signal processing of electrophysiology data in
 Bonsai such as channel selection/reordering, frequency filtering, and fixed-threshold spike
 detection as well as how to listen to ephys data using ONIX hardware and the OpenEphys.Onix1 Bonsai
-package. 
+package.
 
 > [!NOTE]
 > This tutorial serves primarily as an introduction to basic operations for processing electrophysiology data in Bonsai. These operations can also be performed in the Open Ephys GUI which provides advanced visualizations and built-in processing modules.
@@ -32,33 +32,32 @@ package.
 > you might want to use to follow along in this tutorial. It also helps to be familiar with the
 > example workflow for your particular hardware available in the <xref:data-acq-quick-start>.
 
-## Get Started in Bonsai
-
-Follow the [Getting Started](xref:getting-started) guide to set up and familiarize yourself with
-Bonsai. In particular:
-
-- [Download the necessary Bonsai packages](xref:install-configure-bonsai#install-packages)
-or [check for updates](xref:install-configure-bonsai#update-packages) if they're already
-installed. This tutorial assumes you're using the latest packages.
-- Read about [visualizing data](xref:visualize-data). We recommend verifying each step of the
-tutorial by visualizing the data produced.
-
 ## Configure the Hardware
 
-Construct a [top-level hardware configuration chain](xref:onix-configuration): 
+Follow the [Getting Started](xref:getting-started) guide to set up and familiarize yourself with
+Bonsai:
+
+- [Download the necessary Bonsai
+  packages](xref:install-configure-bonsai#installing-packages) or [check for
+  updates](xref:install-configure-bonsai#updating-packages) if they're already
+  installed. This tutorial assumes you're using the latest packages.
+- Read about [visualizing data](xref:visualize-data). We recommend verifying
+  each step of the tutorial by visualizing the data produced.
+
+Construct a [top-level hardware configuration chain](xref:onix-configuration):
 
 ::: workflow
 ![/workflows/tutorials/ephys-process-listen/configure.bonsai workflow](../../workflows/tutorials/ephys-process-listen/configure.bonsai)
 :::
 
-1.  Place the [configuration operators](xref:configure) that corresponds to the hardware you intend
-    to use between <xref:OpenEphys.Onix1.CreateContext> and <xref:OpenEphys.Onix1.StartAcquisition>.
-    In this example, these are <xref:OpenEphys.Onix1.ConfigureBreakoutBoard> and
-    <xref:OpenEphys.Onix1.ConfigureHeadstage64>.
-1.  Confirm that the device that streams electrophysiology data is enabled. The
-    [Rhd2164](https://intantech.com/products_RHD2000.html) device (an Intan ephys acquisition
-    chip) on the headstage 64 is the only device used in this tutorial, so you can
-    disable other devices on the headstage and on the breakout board.
+1. Place the [configuration operators](xref:configure) that corresponds to the hardware you intend
+   to use between <xref:OpenEphys.Onix1.CreateContext> and <xref:OpenEphys.Onix1.StartAcquisition>.
+   In this example, these are <xref:OpenEphys.Onix1.ConfigureBreakoutBoard> and
+   <xref:OpenEphys.Onix1.ConfigureHeadstage64>.
+1. Confirm that the device that streams electrophysiology data is enabled. The
+   [Rhd2164](https://intantech.com/products_RHD2000.html) device (an Intan ephys acquisition
+   chip) on the headstage 64 is the only device used in this tutorial, so you can
+   disable other devices on the headstage and on the breakout board.
 
 ## Stream Ephys Data into Bonsai
 
@@ -68,13 +67,13 @@ Place the relevant operators to stream electrophysiology data from your headstag
 ![/workflows/tutorials/ephys-process-listen/ephys-data.bonsai workflow](../../workflows/tutorials/ephys-process-listen/ephys-data.bonsai)
 :::
 
-1.  We placed the <xref:OpenEphys.Onix1.Rhd2164Data> operator into the workflow because the device on
-    headstage 64 that streams electrophysiology data is the Rhd2164 Intan amplifier. 
-1.  Select the relevant member from the data frames that `Rhd2164Data` produces. In this example, the
-    relevant member is AmplifierData. To do this, right-click `Rhd2164Data`, hover over the
-    output option in the context menu, and select "AmplifierData" from the list.
+1. We placed the <xref:OpenEphys.Onix1.Rhd2164Data> operator into the workflow because the device on
+   headstage 64 that streams electrophysiology data is the Rhd2164 Intan amplifier.
+1. Select the relevant member from the data frames that `Rhd2164Data` produces. In this example, the
+   relevant member is AmplifierData. To do this, right-click `Rhd2164Data`, hover over the
+   output option in the context menu, and select "AmplifierData" from the list.
 
-Visualize the raw data to confirm that the ephys data operator is streaming data. 
+Visualize the raw data to confirm that the ephys data operator is streaming data.
 
 ## Detect Spikes
 
@@ -99,10 +98,11 @@ Connect a <xref:Bonsai.Dsp.ConvertScale> operator to the `SelectChannels` operat
 ![/workflows/tutorials/ephys-process-listen/spike_center-data.bonsai workflow](../../workflows/tutorials/ephys-process-listen/spike_center-data.bonsai)
 :::
 
-- Edit its Shift property to subtract 2^bit depth - 1^ from the signal. In this example, we shift
-  -32768 because the Rhd2164 device outputs unsigned 16-bit data.
-- Set the Depth property to S16 or F32. A sufficiently large data type is required to represent
-  ephys data without overflow.
+- Edit its Shift property to subtract 2^bit depth - 1^ from the signal. In this
+  example, we shift -32768 because the Rhd2164 device outputs unsigned 16-bit
+  data.
+- Set the Depth property to S16 or F32. A sufficiently large data type is
+  required to represent ephys data without overflow.
 
 ### Scale the signal to microvolts
 
@@ -112,21 +112,23 @@ Connect a second `ConvertScale` to the first `ConvertScale` and set its properti
 ![/workflows/tutorials/ephys-process-listen/spike_scale-data.bonsai workflow](../../workflows/tutorials/ephys-process-listen/spike_scale-data.bonsai)
 :::
 
-- Edit its Scale property to multiply the signal by a scalar in order to get microvolt values. This
-  scalar is determined by the gain of the amplifier and resolution the ADC contained in the bioacquisition
-  device. In this example, we scale by 0.195 because the Rhd2164 device on headstage64 has a step size
-  of 0.195&nbsp;μV/bit. 
-- Set the Depth property at F32 which is required to represent decimal values. 
+- Edit its Scale property to multiply the signal by a scalar in order to get
+  microvolt values. This scalar is determined by the gain of the amplifier and
+  resolution the ADC contained in the bioacquisition device. In this example, we
+  scale by 0.195 because the Rhd2164 device on headstage64 has a step size of
+  0.195&nbsp;μV/bit.
+- Set the Depth property at F32 which is required to represent decimal values.
 
-Visualize the transformed data to confirm the output of the shifting and scaling operations are
-performed as expected, i.e. that the signal is centered around zero and that the values make sense
-in microvolts.
+Visualize the transformed data to confirm the output of the shifting and scaling
+operations are performed as expected, i.e. that the signal is centered around
+zero and that the values make sense in microvolts.
 
 > [!NOTE]
-> Although both the shift and scale computations can be done with a single `ConvertScale`, the
-> calculation is more straightforward using two operators connected in series because `ConvertScale`
-> applies the "shift" transformation after applying the "scale" transformation. If we used a single
-> operator, we would have to pre-scale the Shift property.
+> Although both the shift and scale computations can be done with a single
+> `ConvertScale`, the calculation is more straightforward using two operators
+> connected in series because `ConvertScale` applies the "shift" transformation
+> after applying the "scale" transformation. If we used a single operator, we
+> would have to pre-scale the Shift property.
 
 ### Apply a filter
 
@@ -137,19 +139,21 @@ Connect a `FrequencyFilter` operator to the second `ConvertScale` operator and s
 :::
 
 - Set its SampleRate property to 30000. Ephys data in all devices is 30 kHz.
-- Set the FilterType property to an adequate type. In this example, we use a band pass filter to
-  look at spikes and remove slowly changing signals.
-- Set the Cutoff1 and Cutoff2 properties to adequate values. 
+- Set the FilterType property to an adequate type. In this example, we use a
+  band pass filter to look at spikes and remove slowly changing signals.
+- Set the Cutoff1 and Cutoff2 properties to adequate values.
 
 Visualize the filtered data to confirm that it matches your expectations.
 
-> [!TIP] 
-> If you choose to save data, we recommend you place the `MatrixWriter` operator before filtering
-> and scaling to save raw data instead of scaled or filtered data. Converting to microvolts with the
-> second `ConvertScale` operator increases the size of your data (because it's converted to F32 from
-> S16) without increasing meaningful information. Filtering with the `FrequencyFilter` operator
-> before recording removes signal in irrecoverable ways. It's preferable to either save both or apply
-> another filter when loading and processing the data. 
+> [!TIP]
+> If you choose to save data, we recommend you place the `MatrixWriter` operator
+> before filtering and scaling to save raw data instead of scaled or filtered
+> data. Converting to microvolts with the second `ConvertScale` operator
+> increases the size of your data (because it's converted to F32 from S16)
+> without increasing meaningful information. Filtering with the
+> `FrequencyFilter` operator before recording removes signal in irrecoverable
+> ways. It's preferable to either save both or apply another filter when loading
+> and processing the data.
 
 ### Detect spikes with fixed threshold
 
@@ -176,7 +180,7 @@ data stream, one for visualizing spikes in several channels as we did above and 
 :::
 
 The same basic steps as the [Spike Detection](xref:ephys-process-listen#detect-spikes) section are performed.
-However, the property settings are critically different. 
+However, the property settings are critically different.
 
 - Select a single channel for listening instead of multiple channels for detecting spikes.
 - Use the second `ConvertScale` to scale the signal by a value between 0 and 1 to control the volume
@@ -199,14 +203,14 @@ Providing data to `AudioPlayback` that is outside of the bounds of a signed 16&n
 maintain a Scale property value of less than 1 for the volume knob `ConvertScale`. Maximize other
 volume settings on your PC before exceeding 1.
 
-<!-- 
+<!--
 ## Refactoring the Workflow for your purpose
 
 If the processing branches have overlap, it is possible to consolidate them. For example, if your
 filter parameters and offset parameters are identical, this workflow behaves identically as the
 example provided at the top of this page.
 
-> [!TIP] 
+> [!TIP]
 > You can test the spike detection using pre-recorded data known to have spikes: recreate the
 > workflow from this example in a new file without the hardware configuration chain and replace
 > the ephys data-producing operators (in the case of the headstage64, replace the `Rhd2164` and

--- a/articles/tutorials/ephys-socket.md
+++ b/articles/tutorials/ephys-socket.md
@@ -19,8 +19,8 @@ Open Ephys GUI:
 > - This tutorial uses NeuropixelsV1e Headstage as an example, but the process is
 >   similar for other ephys headstages. In fact, this tutorial can be used to send
 >   data from any Bonsai operator that produces [matrices](xref:OpenCV.Net.Mat).
-> - This tutorial assumes you are familiar with the <xref:data-acq-quick-start> 
->   guide for the ONIX headstage you intend to use. 
+> - This tutorial assumes you are familiar with the <xref:data-acq-quick-start>
+>   guide for the ONIX headstage you intend to use.
 > - A [video summary](#video-summary) of this tutorial is available at the
 >   bottom of this page.
 
@@ -29,9 +29,9 @@ Open Ephys GUI:
 Follow the [Getting Started](xref:getting-started) guide to set up and
 familiarize yourself with Bonsai. In particular, [download the necessary Bonsai
 packages](xref:install-configure-bonsai#package-installation) or [check for
-updates](xref:install-configure-bonsai#update-packages) if they're already
+updates](xref:install-configure-bonsai#updating-packages) if they're already
 installed. Once you've done that, copy/paste the following workflow into your
-Bonsai editor. The following sections explain how to create this workflow and 
+Bonsai editor. The following sections explain how to create this workflow and
 configure its elements.
 
 ::: workflow
@@ -48,8 +48,8 @@ set their properties:
 - **Address**: Use "localhost" if you are running Bonsai and the Open Ephys GUI
   on the same machine. Use the IP address of the machine running the GUI if not.
 - **Name**: give the TCP server a unique name. This name is used later in the
-  the workflow to specify to which server to send data. In this example, we have 
-  named them "SpikeServer" and "LfpServer". These names are arbitrary, but in 
+  the workflow to specify to which server to send data. In this example, we have
+  named them "SpikeServer" and "LfpServer". These names are arbitrary, but in
   our example they correspond to the kind of data they will transmit.
 - **Port**: choose a unique [port
   number](https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers). We
@@ -119,7 +119,7 @@ streams. This operator comes from the OpenEphys.Sockets Bonsai package.
 :::
 
 Set the "Connection" property of each `SendMatOverSocket` operator to the name
-of a TCP Socket configured earlier. In this example, "SpikeServer" is used 
+of a TCP Socket configured earlier. In this example, "SpikeServer" is used
 for "SpikeData" and "LfpServer" for "LfPData".
 
 > [!TIP]
@@ -147,8 +147,8 @@ get familiarized with the Open Ephys GUI. In particular:
   [General plugin
   features](https://open-ephys.github.io/gui-docs/User-Manual/Plugins/index.html#general-plugin-features)
 
-Once you've done that, <a href="../../workflows/tutorials/ephys-socket/sockets-signal-chain" download>download</a> 
-the following signal chain and load it into the GUI. The following sections explain how to 
+Once you've done that, <a href="../../workflows/tutorials/ephys-socket/sockets-signal-chain" download>download</a>
+the following signal chain and load it into the GUI. The following sections explain how to
 create this signal chain and configure its elements.
 
 ![cropped screenshot of sockets signal chains A & B](../../images/ephys-socket-tut/sockets-signal-chain.webp)
@@ -174,9 +174,9 @@ In this tutorial we used the following values:
   encoded signed 10-bit data, so 512 corresponds to 0 volts.
 
 > [!TIP]
-> The appropriate scale and offset values for any headstage can be found by navigating to its 
-> respective Data Frame page. For example, those values for the Neuropixels 1.0 device are 
-> available on the <xref:OpenEphys.Onix1.NeuropixelsV1DataFrame> page. 
+> The appropriate scale and offset values for any headstage can be found by navigating to its
+> respective Data Frame page. For example, those values for the Neuropixels 1.0 device are
+> available on the <xref:OpenEphys.Onix1.NeuropixelsV1DataFrame> page.
 
 After configuring `Ephys Socket` processor, press the "Connect" button to
 establish a connection with the `SpikeServer` running in Bonsai.

--- a/articles/tutorials/ephys-socket.md
+++ b/articles/tutorials/ephys-socket.md
@@ -28,7 +28,7 @@ Open Ephys GUI:
 
 Follow the [Getting Started](xref:getting-started) guide to set up and
 familiarize yourself with Bonsai. In particular, [download the necessary Bonsai
-packages](xref:install-configure-bonsai#package-installation) or [check for
+packages](xref:install-configure-bonsai#package-management) or [check for
 updates](xref:install-configure-bonsai#updating-packages) if they're already
 installed. Once you've done that, copy/paste the following workflow into your
 Bonsai editor. The following sections explain how to create this workflow and

--- a/articles/tutorials/index.md
+++ b/articles/tutorials/index.md
@@ -18,4 +18,4 @@ Tutorials include:
 - [Using DataFrameWriter to Save Data](xref:data-frame-writer): explains how to add the
   `DataFrameWriter` operator to an acquisition workflow to save data in the Apache Arrow file
   format which supports efficient random access and partial loading of large datasets. This tutorial
-  also includes guidance on compression and how to load the resulting files in Python. 
+  also includes guidance on compression and how to load the resulting files in Python.

--- a/articles/tutorials/toc.yml
+++ b/articles/tutorials/toc.yml
@@ -1,8 +1,6 @@
 - href: index.md
-  expanded: true
-  items:
-    - href: ephys-processing-listening.md
-    - href: ephys-socket.md
-    - href: tune-readsize.md
-    - href: calibrate-ts4231.md
-    - href: data-frame-writer.md
+- href: ephys-processing-listening.md
+- href: ephys-socket.md
+- href: tune-readsize.md
+- href: calibrate-ts4231.md
+- href: data-frame-writer.md

--- a/template/public/main.css
+++ b/template/public/main.css
@@ -6,12 +6,12 @@
 
 .tableFormat table {
   display: grid;
-  grid-template-columns: auto; 
-  margin-top: 1rem; 
+  grid-template-columns: auto;
+  margin-top: 1rem;
   margin: 0;
   padding: 0;
-  border: 0 hidden; 
-  border-collapse: collapse; 
+  border: 0 hidden;
+  border-collapse: collapse;
 }
 
 .tableFormat td {
@@ -21,9 +21,9 @@
 
 .tableFormat td.term {
   /* !important tag prevents overrides from dotnet.css associated with:
-   body[data-yaml-mime="ManagedReference"] article td.term, body[data-yaml-mime="ApiPage"] article td.term 
+   body[data-yaml-mime="ManagedReference"] article td.term, body[data-yaml-mime="ApiPage"] article td.term
    important tags are not good practice*/
-  font-weight: var(--bs-body-font-weight) !important; 
+  font-weight: var(--bs-body-font-weight) !important;
   white-space: nowrap;
 }
 
@@ -37,7 +37,7 @@
 
 figcaption {
   font-style: italic;
-  border: solid 1px var(--bs-border-color); 
+  border: solid 1px var(--bs-border-color);
   padding: 0.25rem;
 }
 
@@ -49,6 +49,38 @@ ol ol, ol ul {
 
 ol li div {
   margin-bottom: 0rem !important;
+}
+
+
+/* Indent h3-level entries in the "In this article" sidebar */
+
+#affix li:has(.link-secondary) {
+  padding-left: 0.32rem;
+  font-size:0.8rem;
+}
+
+/* Heading size hierarchy within article content */
+article h2 {
+  font-size: 1.75rem;
+}
+
+article h3 {
+  font-size: 1.5rem;
+}
+
+article h4 {
+  font-size: 1.3rem;
+  color: var(--bs-secondary-color);
+}
+
+article h5 {
+  font-size: 1.1rem;
+  color: var(--bs-secondary-color);
+}
+
+article h6 {
+  font-size: 1rem;
+  color: var(--bs-secondary-color);
 }
 
 /* Create color palette for badges */
@@ -258,4 +290,85 @@ li.nav-item > a.nav-link.active {
   justify-content: center;
   background-color: var(--oe-purple-background);
   border-bottom: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
+}
+
+/* Collapsible <details> / <summary> blocks */
+
+:root, [data-bs-theme=light] {
+  --oe-code-bg: #f5f5f5;
+  --oe-details-border-color: color-mix(in srgb, var(--bs-border-color), black 30%);
+}
+
+[data-bs-theme=dark] {
+  --oe-code-bg: #1e1e1e;
+  --oe-details-border-color: color-mix(in srgb, var(--bs-border-color), white 30%);
+}
+
+details {
+  border: var(--bs-border-width) var(--bs-border-style) var(--oe-details-border-color);
+  border-radius: var(--bs-border-radius);
+  margin-bottom: 1rem;
+  background-color: var(--oe-code-bg);
+}
+
+details > summary {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: var(--bs-border-radius);
+  color: var(--bs-link-color);
+  user-select: none;
+}
+
+details > summary::-webkit-details-marker {
+  display: none;
+}
+
+details > summary::before {
+  content: "▶";
+  font-size: 0.7em;
+  transition: transform 0.15s ease;
+  flex-shrink: 0;
+  color: var(--bs-body-color);
+}
+
+details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+details > summary:hover {
+  background-color: var(--bs-tertiary-bg);
+}
+
+details[open] > summary {
+  border-bottom: var(--bs-border-width) var(--bs-border-style) var(--bs-border-color);
+  border-radius: var(--bs-border-radius) var(--bs-border-radius) 0 0;
+}
+
+details[open] > *:not(summary) {
+  padding: 0 0.75rem;
+}
+
+details[open] > *:last-child {
+  padding-bottom: 0.75rem;
+}
+
+details > summary .details-download {
+  margin-left: auto;
+  font-size: 0.875rem;
+  font-weight: normal;
+  color: var(--bs-link-color);
+  text-decoration: none;
+  padding: 0.1rem 0.5rem;
+  border: var(--bs-border-width) var(--bs-border-style) var(--oe-details-border-color);
+  border-radius: var(--bs-border-radius-sm);
+}
+
+details > summary .details-download:hover {
+  color: var(--bs-link-hover-color);
+  background-color: var(--bs-primary-bg-subtle);
+  text-decoration: none;
 }

--- a/template/public/main.js
+++ b/template/public/main.js
@@ -20,5 +20,10 @@ export default {
   ],
   start: () => {
       WorkflowContainer.init();
+
+      // Prevent .details-download links from toggling their parent <details>
+      document.querySelectorAll('summary .details-download').forEach(link => {
+        link.addEventListener('click', e => e.stopPropagation());
+      });
   }
 }


### PR DESCRIPTION
- Edits to DataFrameWriter tutorial
- Style \<details>/<summary\> blocks as bordered cards with animated expand arrow, code-block background, and integrated download button
- Add heading size hierarchy and h3 indentation in the "In this article" sidebar to CSS
- Fix "Tutorials/Tutorials" breadcrumb duplication by flattening articles/tutorials/toc.yml
- Add introductory paragraph under "Use Multiple Instances of Identical Hardware" in onix-acquisition.md
- Rewrite api/configure.md intro to clarify distinction between combined and per-device configuration operators
- Reformat install-configure-bonsai.md and calibrate-ts4231.md to use "-" list markers and consistent indentation