### PR TITLE
Do not validate external links with doclinkchecker

### DIFF
--- a/.github/workflows/DocLinkChecker.config
+++ b/.github/workflows/DocLinkChecker.config
@@ -17,7 +17,7 @@
     "CheckForOrphanedResources": true,
     "CleanupOrphanedResources": false,
     "ValidatePipeTableFormatting": true,
-    "ValidateExternalLinks": true,
+    "ValidateExternalLinks": false,
     "ConcurrencyLevel": 1,
     "MaxHttpRedirects": 20,
     "ExternalLinkDurationWarning": 3000,

--- a/.github/workflows/DocLinkChecker.config
+++ b/.github/workflows/DocLinkChecker.config
@@ -18,7 +18,7 @@
     "CleanupOrphanedResources": false,
     "ValidatePipeTableFormatting": true,
     "ValidateExternalLinks": false,
-    "ConcurrencyLevel": 1,
+    "ConcurrencyLevel": 5,
     "MaxHttpRedirects": 20,
     "ExternalLinkDurationWarning": 3000,
     "WhitelistUrls": [

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Check HTML Links After Building
         uses: lycheeverse/lychee-action@v2
         with:
-          args: --verbose --no-progress --root-dir "${{ github.workspace }}/_site" --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* --exclude '\.(pdf)$' --max-retries 0 --max-concurrency 32 --cache --max-cache-age 1d '**/*.html'
+          args: --verbose --no-progress --root-dir "${{ github.workspace }}/_site" --exclude ^https://github\.com.*merge.* --exclude ^https://github\.com.*apiSpec.* --max-retries 0 --max-concurrency 32 --cache --max-cache-age 1d '**/*.html'
           fail: true
 
   deploy:


### PR DESCRIPTION
- doclinkchecker external link validation is finnicky
  - InvalidMediaType warnings fail the build process (frequently with references to intantech.com)
  - TooManyRequests warnings fail the build process (frequently with references to wikipedia.com)
- It seems random when it passes and fails. Sometimes I retrigger the workflow action without changing after failing and it passes the second time
- lychee external link validation suffices and doesn't cause build failures